### PR TITLE
Update/0.3.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ml_dtypes" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ml_dtypes-{{ version }}.tar.gz
-  sha256: 6488eb642acaaf08d8020f6de0a38acee7ac324c1e6e92ee0c0fea42422cb797
+  sha256: 60778f99194b4c4f36ba42da200b35ef851ce4d4af698aaf70f5b91fe70fc611
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: True # [py<39]
 
 requirements:
   build:
@@ -21,7 +22,7 @@ requirements:
     - python
     - numpy {{ numpy }}
     - pybind11 2.10
-    - setuptools >=67.6.0,<68
+    - setuptools >=68.1.0,<69
     - pip
     - wheel
   run:
@@ -33,15 +34,7 @@ test:
     - ml_dtypes
   commands:
     - pip check
-    - pytest -n auto  # [not ppc64le]
-    - pytest --dist no  # [ppc64le]
-  source_files:
-    - ml_dtypes/tests
-  requires:
-    - pip
-    - pytest
-    - pytest-xdist
-    - absl-py
+    # Maintainers dropped tests from source builds, we may want to build from source if problems are found.
 
 about:
   home: https://pypi.org/project/ml-dtypes/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
 test:
   imports:
     - ml_dtypes
+  requires:
+    - pip
   commands:
     - pip check
     # Maintainers dropped tests from source builds, we may want to build from source if problems are found.


### PR DESCRIPTION
ml_dytpes 0.3.1

**Destination channel:** main

### Links

- [PKG-3321](https://anaconda.atlassian.net/browse/PKG-3321) 
- [Upstream repository](https://github.com/jax-ml/ml_dtypes)
- [Upstream changelog/diff](https://github.com/jax-ml/ml_dtypes/compare/v0.2.0..v0.3.1)

### Explanation of changes:

- Bump version and hash
- Added abs.yaml to build with and for Python 3.12
- Removed pytest tests as they are no longer bundled in the source build


[PKG-3321]: https://anaconda.atlassian.net/browse/PKG-3321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ