### PR TITLE
v0.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ml_dtypes" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ml_dtypes-{{ version }}.tar.gz
-  sha256: eaf197e72f4f7176a19fe3cb8b61846b38c6757607e7bf9cd4b1d84cd3e74deb
+  sha256: 3e7d3a380fe73a63c884f06136f8baa7a5249cc8e9fdec677997dd78549f8128
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -20,13 +20,17 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - numpy {{ numpy }}
+    - numpy 2
     - setuptools
     - pip
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.21    [py<=39]
+    - numpy >=1.21.2  [py==310]
+    - numpy >=1.23.3  [py==311]
+    - numpy >=1.26.0  [py==312]
+    - numpy >=2.1.0   [py>=313]
 
 test:
   imports:


### PR DESCRIPTION
ml_dtypes v0.5.0

**Destination channel:**  defaults

### Links

- [PKG-4841](https://anaconda.atlassian.net/browse/PKG-4841) 
- [Upstream repository](https://github.com/jax-ml/ml_dtypes/tree/v0.5.0)
- [pyproject.toml](https://github.com/jax-ml/ml_dtypes/blob/v0.5.0/pyproject.toml)

### Explanation of changes:

- Use numpy 2
- Build for python 3.13



[PKG-4841]: https://anaconda.atlassian.net/browse/PKG-4841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ